### PR TITLE
Fix nginx reverse proxy bug

### DIFF
--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -56,7 +56,7 @@ http {
 	# Virtual Host Configs
 	##
 
-	include /etc/nginx/conf.d/*.conf;
+	# include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;
 	
 	upstream manager {
@@ -67,13 +67,13 @@ http {
 		listen 80;
 		root /usr/share/nginx/html;
 
-		location /Login$ {
+		location /Login {
 			proxy_pass	http://manager/Login/;
 			proxy_redirect	off;
 			proxy_set_header   Host $host;
-		    proxy_set_header   X-Real-IP $remote_addr;
-		    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-		    proxy_set_header   X-Forwarded-Host $server_name;
+			proxy_set_header   X-Real-IP $remote_addr;
+			proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header   X-Forwarded-Host $server_name;
 		}
 	}
 }


### PR DESCRIPTION
Remove `including /etc/nginx/conf.d/default.conf`, otherwise the server block will not work.
